### PR TITLE
👍  Togglable linkify option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /dist
+.node-version

--- a/README.md
+++ b/README.md
@@ -12,38 +12,29 @@ yarn add quill-linkify
 
 ```ts
 import Quill from 'quill';
-import { Linkify } from 'quill-linkify';
+import { Linkify, Options } from 'quill-linkify';
 
 Quill.register('modules/linkify', Linkify);
 
-const quill = new Quill("Element", {
-  modules: {
-    linkify: true,
-  },
-});
-```
-
-## Regular Expression
-| Type | RegExp |
-| --- | --- |
-| URL | `/(https?:\/\/\|www\.)[\w-\.]+\.[\w-\.]+(\/([\S]+)?)?/i` |
-| Mail | `/([\w-\.]+@[\w-\.]+\.[\w-\.]+)/i` |
-| Phone number | `/(((0(\d{1}[-(]?\d{4}\|\d{2}[-(]?\d{3}\|\d{3}[-(]?\d{2}\|\d{4}[-(]?\d{1}\|[5789]0[-(]?\d{4})[-)]?)\|\d{1,4}-?)\d{4}\|0120[-(]?\d{3}[-)]?\d{3})/i` |
-
-If you want to customize Regular Expression, please refer to the following.
-
-```ts
-import { Options } from 'quill-linkify';
-
 const linkifyOptions: Options = {
-  url: /url regexp/,
-  mail: /mail regexp/,
-  phoneNumber: /phone number regexp/,
+  /* custom (regexp or true) or (false or undefined) */
+  url: /foo/, // Use custom regexp
+  mail: true, // Use default regexp
+  phoneNumber: false, // Disable text auto link
 };
 
 const quill = new Quill("Element", {
   modules: {
     linkify: linkifyOptions,
+    // or true (Use default regep)
   },
 });
+
 ```
+
+## Default Regular Expression
+| Type | RegExp |
+| --- | --- |
+| URL | `/(https?:\/\/\|www\.)[\w-\.]+\.[\w-\.]+(\/([\S]+)?)?/i` |
+| Mail | `/([\w-\.]+@[\w-\.]+\.[\w-\.]+)/i` |
+| Phone number | `/(((0(\d{1}[-(]?\d{4}\|\d{2}[-(]?\d{3}\|\d{3}[-(]?\d{2}\|\d{4}[-(]?\d{1}\|[5789]0[-(]?\d{4})[-)]?)\|\d{1,4}-?)\d{4}\|0120[-(]?\d{3}[-)]?\d{3})/i` |

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,13 @@ import Quill from 'quill';
 import Delta from 'quill-delta';
 
 import { MailType, PhoneNumberType, UrlType } from './linkTypes';
+import { AbstractType } from './linkTypes/AbstractType';
 import { QuillLinkify } from './quillLinkify';
 
 export type Options = {
-  url?: RegExp;
-  mail?: RegExp;
-  phoneNumber?: RegExp;
+  url?: RegExp | boolean;
+  mail?: RegExp | boolean;
+  phoneNumber?: RegExp | boolean;
 };
 
 export class Linkify {
@@ -15,13 +16,22 @@ export class Linkify {
 
   quillLinkify: QuillLinkify;
 
-  constructor(quill: Quill, options?: Options) {
+  constructor(quill: Quill, options: Options) {
+    const typeList: AbstractType[] = [];
+
+    console.log(options)
+    if (!Object.keys(options).length) {
+      typeList.push(new UrlType(true))
+      typeList.push(new MailType(true))
+      typeList.push(new PhoneNumberType(true))
+    } else if (options) {
+      options.url && typeList.push(new UrlType(options.url))
+      options.mail && typeList.push(new MailType(options.mail))
+      options.phoneNumber && typeList.push(new PhoneNumberType(options.phoneNumber))
+    }
+
     this.quill = quill;
-    this.quillLinkify = new QuillLinkify([
-      new UrlType(options?.url),
-      new MailType(options?.mail),
-      new PhoneNumberType(options?.phoneNumber)
-    ]);
+    this.quillLinkify = new QuillLinkify(typeList)
     this.pasteListener();
     this.typeListener();
   }

--- a/src/linkTypes/MailType.ts
+++ b/src/linkTypes/MailType.ts
@@ -3,8 +3,8 @@ import { AbstractType } from './AbstractType';
 export const MailRegularExpression = /([\w-\.]+@[\w-\.]+\.[\w-\.]+)/i;
 
 export class MailType extends AbstractType {
-  constructor(regexp?: RegExp) {
-    super(regexp || MailRegularExpression);
+  constructor(regexp: RegExp | true) {
+    super(regexp === true ? MailRegularExpression : regexp);
   }
 
   normalize = (text: string): string => `mailto:${text}`;

--- a/src/linkTypes/PhoneNumberType.ts
+++ b/src/linkTypes/PhoneNumberType.ts
@@ -3,8 +3,8 @@ import { AbstractType } from './AbstractType';
 export const PhoneNumberRegularExpression = /(((0(\d{1}[-(]?\d{4}|\d{2}[-(]?\d{3}|\d{3}[-(]?\d{2}|\d{4}[-(]?\d{1}|[5789]0[-(]?\d{4})[-)]?)|\d{1,4}-?)\d{4}|0120[-(]?\d{3}[-)]?\d{3})/i;
 
 export class PhoneNumberType extends AbstractType {
-  constructor(regexp?: RegExp) {
-    super(regexp || PhoneNumberRegularExpression);
+  constructor(regexp: RegExp | true) {
+    super(regexp === true ? PhoneNumberRegularExpression : regexp);
   }
 
   normalize = (text: string): string => `tel:${text}`;

--- a/src/linkTypes/UrlType.ts
+++ b/src/linkTypes/UrlType.ts
@@ -3,8 +3,8 @@ import { AbstractType } from './AbstractType';
 export const UrlRegularExpression = /(https?:\/\/|www\.)[\w-\.]+\.[\w-\.]+(\/([\S]+)?)?/i;
 
 export class UrlType extends AbstractType {
-  constructor(regexp?: RegExp) {
-    super(regexp || UrlRegularExpression);
+  constructor(regexp: RegExp | true) {
+    super(regexp === true ? UrlRegularExpression : regexp);
   }
 
   normalize = (text: string): string => text;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,6 +1,6 @@
 import Quill from "quill";
 import Delta from "quill-delta";
-import { Linkify } from "../src/index";
+import { Linkify, Options } from "../src/index";
 
 describe("Linkify", () => {
   describe("PasteListener", () => {
@@ -13,14 +13,19 @@ describe("Linkify", () => {
             matcherCallback = callback;
           }
         },
-        on: () => {},
-        getSelection: () => {},
-        getLeaf: () => {},
-        getIndex: () => {},
-        updateContents: () => {},
+        on: () => { },
+        getSelection: () => { },
+        getLeaf: () => { },
+        getIndex: () => { },
+        updateContents: () => { },
       } as unknown as Quill;
+      const options = {
+        url: true,
+        mail: true,
+        phoneNumber: true,
+      };
 
-      new Linkify(quillMock);
+      new Linkify(quillMock, options);
     });
 
     test('should not alter plain text', () => {
@@ -162,6 +167,57 @@ describe("Linkify", () => {
           { insert: ' ' }
         ],
       })
+    })
+  })
+
+  describe("Linkify Option", () => {
+    let matcherCallback: (node: Text, delta: Delta) => Delta;
+
+    const initialize = (options: Options) => {
+      const quillMock = {
+        clipboard: {
+          addMatcher: (_nodeType: string | number, callback: (node: Text, delta: Delta) => Delta) => {
+            matcherCallback = callback;
+          }
+        },
+        on: () => { },
+        getSelection: () => { },
+        getLeaf: () => { },
+        getIndex: () => { },
+        updateContents: () => { },
+      } as unknown as Quill;
+
+      return new Linkify(quillMock, options);
+    };
+
+    test("should include url, mail, phone-number", () => {
+      const linkify = initialize({});
+      expect(linkify.quillLinkify.typeList.length).toEqual(3)
+    })
+
+    test("should not include url, mail, phone-number", () => {
+      const linkify = initialize({
+        url: false,
+        mail: false,
+        phoneNumber: false
+      });
+      expect(linkify.quillLinkify.typeList.length).toEqual(0)
+    })
+
+    test("should include only url", () => {
+      const linkify = initialize({
+        url: true,
+        mail: false,
+      });
+      expect(linkify.quillLinkify.typeList.length).toEqual(1)
+    })
+
+    test("should custom regexp only url", () => {
+      const linkify = initialize({
+        url: /sample/,
+      });
+      expect(linkify.quillLinkify.typeList.length).toEqual(1)
+      expect(linkify.quillLinkify.typeList[0].regexp).toEqual(/sample/)
     })
   })
 })


### PR DESCRIPTION
## Why

https://github.com/kyoncy/quill-linkify/issues/2#issue-941292884

> 2\. Possible to provide an option to turn off needless matching, eg I dont want phone matching. So perhaps the options can allow turning off this matching.

## What
If you want disable phone number matching, you can write code below

```ts
import Quill from 'quill';
import { Linkify, Options } from 'quill-linkify';

Quill.register('modules/linkify', Linkify);

const linkifyOptions: Options = {
  url: true,
  mail: true,
  phoneNumber: false, // or not set phoneNumber key
};

const quill = new Quill("Element", {
  modules: {
    linkify: linkifyOptions,
  },
});
```